### PR TITLE
chore(release): 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+### [1.0.3](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.2...v1.0.3) (2021-06-07)
+
+
+### Bug Fixes
+
+* Ahora si ([1ab0279](https://github.com/gquiles-perez911/npm-automated-release/commit/1ab027949112d5cc3066327a267c0720569092bf))
+* Vamos a ver ([6d0aa04](https://github.com/gquiles-perez911/npm-automated-release/commit/6d0aa04e3910e7931b6ee65dbaaf2a42d0ce3300))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "dist/index.js",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.0.3](https://github.com/gquiles-perez911/npm-automated-release/releases/tag/v1.0.3).