### PR TITLE
chore(release): 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### [1.0.4](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.3...v1.0.4) (2021-06-16)
+
+
+### Bug Fixes
+
+* Hello ([850f623](https://github.com/gquiles-perez911/npm-automated-release/commit/850f62344f761af91a05c0ae7e5feb02da4c43e9))
+
 ### [1.0.3](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.2...v1.0.3) (2021-06-07)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "dist/index.js",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.0.4](https://github.com/gquiles-perez911/npm-automated-release/releases/tag/v1.0.4).