### PR TITLE
chore(release): 1.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### [1.0.8](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.7...v1.0.8) (2021-09-24)
+
+
+### Bug Fixes
+
+* **p:** asdas ([70c63cb](https://github.com/gquiles-perez911/npm-automated-release/commit/70c63cbf32dc36d9f291a02b1cb63570a2f83b73))
+
 ### [1.0.6](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.5...v1.0.6) (2021-09-24)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "main": "dist/index.js",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.0.8](https://github.com/gquiles-perez911/npm-automated-release/releases/tag/v1.0.8).