### PR TITLE
chore(release): 1.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### [1.0.12](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.11...v1.0.12) (2021-09-24)
+
+
+### Bug Fixes
+
+* **12312:** asdasd ([19e54bd](https://github.com/gquiles-perez911/npm-automated-release/commit/19e54bdb639cd8c1d861ef62e92eb5d1824bacdf))
+
 ### [1.0.11](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.10...v1.0.11) (2021-09-24)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "main": "dist/index.js",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.0.12](https://github.com/gquiles-perez911/npm-automated-release/releases/tag/v1.0.12).