### PR TITLE
chore(release): 1.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### [1.0.13](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.12...v1.0.13) (2021-09-24)
+
+
+### Bug Fixes
+
+* **12312:** asdasdas ([8c14d9a](https://github.com/gquiles-perez911/npm-automated-release/commit/8c14d9a75be45c399bc8201c1861c5270b8d6920))
+
 ### [1.0.12](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.11...v1.0.12) (2021-09-24)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "main": "dist/index.js",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.0.13](https://github.com/gquiles-perez911/npm-automated-release/releases/tag/v1.0.13).