### PR TITLE
chore(release): 1.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### [1.0.15](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.14...v1.0.15) (2021-09-24)
+
+
+### Bug Fixes
+
+* **12312:** asdsada ([2a8f05e](https://github.com/gquiles-perez911/npm-automated-release/commit/2a8f05e429e8e49e614dacf9b3d1a88aba28eca9))
+
 ### [1.0.14](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.13...v1.0.14) (2021-09-24)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "main": "dist/index.js",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.0.15](https://github.com/gquiles-perez911/npm-automated-release/releases/tag/v1.0.15).