### PR TITLE
chore(release): 1.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### [1.0.16](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.15...v1.0.16) (2021-09-24)
+
+
+### Bug Fixes
+
+* **123:** 12312 ([56aa38e](https://github.com/gquiles-perez911/npm-automated-release/commit/56aa38e4be077a0b2f26c860f12baecb3ca1a913))
+
 ### [1.0.15](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.14...v1.0.15) (2021-09-24)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "main": "dist/index.js",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.0.16](https://github.com/gquiles-perez911/npm-automated-release/releases/tag/v1.0.16).