### PR TITLE
chore(release): 1.0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### [1.0.17](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.16...v1.0.17) (2021-09-24)
+
+
+### Bug Fixes
+
+* **123:** asdasd ([ab46799](https://github.com/gquiles-perez911/npm-automated-release/commit/ab46799493ec72c69a4954cd11c4f3c8a3fed2bd))
+
 ### [1.0.16](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.15...v1.0.16) (2021-09-24)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "main": "dist/index.js",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.0.17](https://github.com/gquiles-perez911/npm-automated-release/releases/tag/v1.0.17).