### PR TITLE
chore(release): 1.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### [1.0.18](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.17...v1.0.18) (2021-09-24)
+
+
+### Bug Fixes
+
+* **12312:** asdsada ([3e5ea33](https://github.com/gquiles-perez911/npm-automated-release/commit/3e5ea3360a4211e22b9ffd4bdba3e345f11cd632))
+
 ### [1.0.17](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.16...v1.0.17) (2021-09-24)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "main": "dist/index.js",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.0.18](https://github.com/gquiles-perez911/npm-automated-release/releases/tag/v1.0.18).