### PR TITLE
chore(release): 1.0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### [1.0.19](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.18...v1.0.19) (2021-09-24)
+
+
+### Bug Fixes
+
+* **123:** asdsa ([a26a0e3](https://github.com/gquiles-perez911/npm-automated-release/commit/a26a0e372b0a5010a3285887493ba45c2d8fae48))
+
 ### [1.0.18](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.17...v1.0.18) (2021-09-24)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "main": "dist/index.js",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.0.19](https://github.com/gquiles-perez911/npm-automated-release/releases/tag/v1.0.19).