### PR TITLE
chore(release): 1.0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### [1.0.20](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.19...v1.0.20) (2021-09-24)
+
+
+### Bug Fixes
+
+* **123:** asdas ([040085a](https://github.com/gquiles-perez911/npm-automated-release/commit/040085a5a3f38300d6cdab16b2ecee0197618b60))
+
 ### [1.0.19](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.18...v1.0.19) (2021-09-24)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "main": "dist/index.js",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.0.20](https://github.com/gquiles-perez911/npm-automated-release/releases/tag/v1.0.20).