### PR TITLE
chore(release): 1.0.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### [1.0.22](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.21...v1.0.22) (2021-09-24)
+
+
+### Bug Fixes
+
+* **123:** 123123 ([dc1d76d](https://github.com/gquiles-perez911/npm-automated-release/commit/dc1d76d2cb6a03fa5189df0bb894f7672a0bbdb8))
+
 ### [1.0.21](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.20...v1.0.21) (2021-09-24)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "main": "dist/index.js",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.0.22](https://github.com/gquiles-perez911/npm-automated-release/releases/tag/v1.0.22).