### PR TITLE
chore(release): 1.0.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### [1.0.23](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.22...v1.0.23) (2021-09-24)
+
+
+### Bug Fixes
+
+* **12321:** 1231234 ([27d7aaa](https://github.com/gquiles-perez911/npm-automated-release/commit/27d7aaa966e8b07afb9655b7ee3191ffe2aa4422))
+
 ### [1.0.22](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.21...v1.0.22) (2021-09-24)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "main": "dist/index.js",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.0.23](https://github.com/gquiles-perez911/npm-automated-release/releases/tag/v1.0.23).