### PR TITLE
chore(release): 1.0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### [1.0.24](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.23...v1.0.24) (2021-09-24)
+
+
+### Bug Fixes
+
+* **123:** 12312312 ([fc1c0aa](https://github.com/gquiles-perez911/npm-automated-release/commit/fc1c0aaba7bfb961c71b4dc18cff3bb36279413b))
+
 ### [1.0.23](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.22...v1.0.23) (2021-09-24)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "main": "dist/index.js",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.0.24](https://github.com/gquiles-perez911/npm-automated-release/releases/tag/v1.0.24).