### PR TITLE
chore(release): 1.0.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### [1.0.25](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.24...v1.0.25) (2021-09-27)
+
+
+### Bug Fixes
+
+* **123:** 123123 ([262bdbc](https://github.com/gquiles-perez911/npm-automated-release/commit/262bdbcdf2678d07478ca82e3b2fb5d904a93cad))
+
 ### [1.0.24](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.23...v1.0.24) (2021-09-24)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "main": "dist/index.js",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.0.25](https://github.com/gquiles-perez911/npm-automated-release/releases/tag/v1.0.25).