### PR TITLE
chore(release): 1.0.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### [1.0.26](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.25...v1.0.26) (2021-09-27)
+
+
+### Bug Fixes
+
+* **123:** 12312 ([dfab1d1](https://github.com/gquiles-perez911/npm-automated-release/commit/dfab1d13512c2e37a542ffafc2f87b13f5975864))
+
 ### [1.0.25](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.24...v1.0.25) (2021-09-27)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "main": "dist/index.js",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.0.26](https://github.com/gquiles-perez911/npm-automated-release/releases/tag/v1.0.26).