### PR TITLE
chore(release): 1.0.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### [1.0.27](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.26...v1.0.27) (2021-09-27)
+
+
+### Bug Fixes
+
+* **123:** dscsdfds ([77aebe6](https://github.com/gquiles-perez911/npm-automated-release/commit/77aebe69560c1abefbb3e6c7cd55329a026c836f))
+
 ### [1.0.26](https://github.com/gquiles-perez911/npm-automated-release/compare/v1.0.25...v1.0.26) (2021-09-27)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DocumentViewer",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "main": "dist/index.js",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.0.27](https://github.com/gquiles-perez911/npm-automated-release/releases/tag/v1.0.27).